### PR TITLE
Adds functionality to hide tasks when not running. Per #2

### DIFF
--- a/golist.go
+++ b/golist.go
@@ -67,6 +67,7 @@ type List struct {
 	Writer          io.Writer        // Writer to use for printing output
 	MaxLineLength   int              // Maximum line length for printing (0 = no limit)
 	StatusIniicator StatusIndicators // Map of statuses to status indicators
+	ClearOnComplete bool             // If true, the list will clear the list after it finishes running
 
 	running bool               // Is the list running?
 	cancel  context.CancelFunc // A context cancel function for stopping the list run
@@ -198,7 +199,9 @@ func (l *List) Stop() {
 	// Clear and print one final time (NOTE: should this be an option?)
 	ts := l.getTaskStates()
 	l.clear(ts)
-	l.print(ts)
+	if !l.ClearOnComplete {
+		l.print(ts)
+	}
 
 	l.running = false
 	l.cancel = nil


### PR DESCRIPTION
Adding the `ClearOnComplete` parameter to the `List`, to determine
if the list is printed a final time after completing and calling
the `Stop` function. The default value (`ClearOnComplete = false`)
is to keep the list.

Adding the `HideTasksWhenNotRunning` parameter to `TaskGroups` to
hide subtasks when the group is not running. This is similar to
the `List.ClearOnComplete` except that it will still show it's own
`Message` value when the subtasks are cleared and it will hide
subtasks _before_ as well as after the `TaskGroup` runs. The
difference is because the `List` doesn't have a `Message` to display
and the user can already control the pre-run list display via the
time between the `Start` and `Run` commands. The two parameters
are named differently to help suggest the difference.
