### PR TITLE
Fixing issue with concurrent TaskGroups

### DIFF
--- a/taskgroup.go
+++ b/taskgroup.go
@@ -62,6 +62,7 @@ func (tg *TaskGroup) runAsync(c TaskContext) error {
 			t.Run(c)
 		}(t)
 	}
+	wg.Wait()
 	return tg.GetError()
 }
 


### PR DESCRIPTION
TaskGroups running concurrently weren't waiting for the WaitGroup
before finishing.
